### PR TITLE
Allow running from Windows

### DIFF
--- a/server.js
+++ b/server.js
@@ -287,7 +287,7 @@ function compileHyperloopBundle(entry, compiler) {
 }
 
 function makeWebpackConfig(entry, config = {}) {
-  if (!(entry[0] === '/' || entry.slice(0, 1) === 'C:')) {
+  if (!path.isAbsolute(entry)) {
     throw new Error('path to root component must be absolute, not relative')
   }
 

--- a/server.js
+++ b/server.js
@@ -287,7 +287,7 @@ function compileHyperloopBundle(entry, compiler) {
 }
 
 function makeWebpackConfig(entry, config = {}) {
-  if (entry[0] !== '/') {
+  if (!(entry[0] === '/' || entry.slice(0, 1) === 'C:')) {
     throw new Error('path to root component must be absolute, not relative')
   }
 


### PR DESCRIPTION
Currently throws an error when you try to run from Windows, because file paths look like this:

```
C:\Users\username\Documents\...
```

This allows for filepaths that start with `C:`