### PR TITLE
Fix server's this.location.url

### DIFF
--- a/server.js
+++ b/server.js
@@ -137,7 +137,7 @@ class HyperloopContext {
       query: req.query,
       setStatus: this.setStatus.bind(this),
       ip: req.ip,
-      url: this.originalUrl,
+      url: req.originalUrl,
       userAgent: req.get('User-Agent') || 'Unknown',
     }
     this.body = req.body


### PR DESCRIPTION
Currently `this.location.url` is always `undefined` on the server.

This fixes to show the proper url.